### PR TITLE
Change user API key path

### DIFF
--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,9 +1,19 @@
-import { useUser } from '@auth0/nextjs-auth0/client';
-import { Button, Box, Text, Heading, Container, Spacer, Menu, MenuButton, MenuList, MenuItem } from '@chakra-ui/react';
+import { useUser } from "@auth0/nextjs-auth0/client";
+import {
+  Button,
+  Box,
+  Text,
+  Heading,
+  Container,
+  Spacer,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+} from "@chakra-ui/react";
 import Header from "../components/Header";
-import { useRouter } from 'next/router';
-import axios from 'axios';
-
+import { useRouter } from "next/router";
+import axios from "axios";
 
 function UserProfile() {
   const { user, error, isLoading } = useUser();
@@ -11,8 +21,8 @@ function UserProfile() {
 
   const logout = async () => {
     try {
-      await axios.post('/api/auth/logout');
-      router.push('/');
+      await axios.post("/api/auth/logout");
+      router.push("/");
     } catch (err) {
       console.log(err);
     }
@@ -34,10 +44,11 @@ function UserProfile() {
           <Box p={5} borderWidth="1px" borderRadius="lg">
             <Heading size="xl">Welcome, {user.name}!</Heading>
             <Text mt={4} fontSize="lg">
-              Your Marketer API Key: {user['https://seshatlabs.xyz/marketer_api_key']}
+              Your Marketer API Key: {user.seshat_API_keys.marketerAPIKey}
             </Text>
             <Text mt={4} fontSize="lg">
-              Your Publisher/DApp Developer API Key: {user['https://seshatlabs.xyz/publisher_api_key']}
+              Your Publisher/DApp Developer API Key:{" "}
+              {user.seshat_API_keys.publisherAPIKey}
             </Text>
             <Spacer mt={6} />
             <Menu>
@@ -59,9 +70,13 @@ function UserProfile() {
       <Header />
       <Container maxW="xl" mt={80} textAlign="center">
         <Text fontSize="xl" mb={4}>
-          You are not logged in, please hit the continue to create a new account or login into your account.
+          You are not logged in, please hit the continue to create a new account
+          or login into your account.
         </Text>
-        <Button colorScheme="blue" onClick={() => router.push('/api/auth/login')}>
+        <Button
+          colorScheme="blue"
+          onClick={() => router.push("/api/auth/login")}
+        >
           Login
         </Button>
       </Container>


### PR DESCRIPTION
## SOC-125

On auth0, I added a post-login action flow that triggers when users log in that adds the marketer and publisher API keys to their user profile. Currently, the flow only triggers, on the first login or if the user does not have any API keys

Since the paths to get the proper keys in the user profile have changed, we had to update the code.