### PR TITLE
Hotfix upload ads

### DIFF
--- a/pages/api/create_campaign.js
+++ b/pages/api/create_campaign.js
@@ -1,57 +1,83 @@
-import formidable from 'formidable';
-import { dbConnect } from '../../data-engine/ETL/helper/mongohelper'
-import Advertiser from '../../backend/entities/advertiser.entity'
-import Campaign from '../../backend/entities/campaign.entity'
+import formidable from "formidable";
+import { dbConnect } from "../../data-engine/ETL/helper/mongohelper";
+import Advertiser from "../../backend/entities/advertiser.entity";
+import Campaign from "../../backend/entities/campaign.entity";
 import fs from "fs";
 
 export const config = {
-    api: {
-        bodyParser: false
-    }
+  api: {
+    bodyParser: false,
+  },
 };
 
 const saveCampaign = async (fields, file) => {
-    const {description, advertiser, mode, title, budget, duration} = fields;
-    const timeRemaining = duration;
-    const runningStatus = true;
-    const lastStatusChange = Date.now();
-    const media = fs.readFileSync(file.filepath);
-    const campaign = new Campaign({media, description, advertiser, mode, title, budget, runningStatus, lastStatusChange, timeRemaining})
-    console.log({media, description, advertiser, mode, title, budget, runningStatus, lastStatusChange, timeRemaining})
-    await campaign.save();
-    return;
+  const { description, advertiser, mode, title, budget, duration } = fields;
+  const timeRemaining = duration;
+  const runningStatus = true;
+  const lastStatusChange = Date.now();
+  const media = fs.readFileSync(file.filepath);
+  const campaign = new Campaign({
+    media,
+    description,
+    advertiser,
+    mode,
+    title,
+    budget,
+    runningStatus,
+    lastStatusChange,
+    timeRemaining,
+  });
+  console.log({
+    media,
+    description,
+    advertiser,
+    mode,
+    title,
+    budget,
+    runningStatus,
+    lastStatusChange,
+    timeRemaining,
+  });
+  await campaign.save();
+  return;
 };
 
 export default async function handler(req, res) {
-    const form = new formidable.IncomingForm();
-    form.uploadDir = "./";
-    form.keepExtensions = true;
-    dbConnect();
-    const { method } = req;
+  const form = new formidable.IncomingForm();
+  form.uploadDir = "./";
+  form.keepExtensions = true;
+  dbConnect();
+  const { method } = req;
 
-    const ad = await Advertiser.findOne();
-    if (!ad) {
-        console.log('a')
-        const testAdvertiser = new Advertiser({name: "test"});
-        testAdvertiser.save();
-    } 
+  const ad = await Advertiser.findOne();
+  if (!ad) {
+    console.log("a");
+    const testAdvertiser = new Advertiser({ name: "test" });
+    testAdvertiser.save();
+  }
 
-    switch (method) {
-        case 'POST':
-            try {
-                form.parse(req, async function (err, fields, files) {
-                    console.log(err, fields, files)
-                    await saveCampaign(fields, files.files);
-
-                    return res.status(201).send("");
-                });
-            } catch (error) {
-                res.status(400).json({ success: false, data: error })
+  switch (method) {
+    case "POST":
+      try {
+        const formPromise = await new Promise((resolve, reject) => {
+          form.parse(req, async function (err, fields, files) {
+            console.log(err, fields, files);
+            if (err) {
+              reject(err);
             }
-            break
-        default:
-            res.status(400).json({ success: false })
-            break
-    }
 
+            await saveCampaign(fields, files.files);
+
+            resolve({ success: true });
+          });
+        });
+        res.status(201).json(formPromise);
+      } catch (error) {
+        res.status(400).json({ success: false, data: error });
+      }
+      break;
+    default:
+      res.status(400).json({ success: false });
+      break;
+  }
 }


### PR DESCRIPTION
## Hotfix to allow uploads to the production server

### When hitting the `/create_campaign` endpoint, we consistently got a warning similar to:

> API resolved without sending a response for .../create_campaign, this may result in stalled requests.

Resolved this by reading the 2 links and implementing their solutions: 
https://stackoverflow.com/questions/72419522/whats-the-proper-way-for-returning-a-response-using-formidable-on-nextjs-api
https://stackoverflow.com/questions/75393532/how-to-upload-a-file-with-nextjs-and-formidable

### Unable to upload files to Vercel server as it is a read-only file system
Resolved this by removing the manual configuration of the upload directory of our form submission. The default upload directory is the output of `os.tmpdir()` according to their [docs](https://github.com/node-formidable/formidable#api)

Source:
https://stackoverflow.com/questions/66302483/how-can-i-upload-file-using-formidable-with-nextjs-on-vercel


