### PR TITLE
Add MetaMask wallet login and info display functionality

### DIFF
--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -1,113 +1,131 @@
 import {
-    Box,
-    Flex,
-    HStack,
-    IconButton,
-    Link,
-    useDisclosure,
-    useColorModeValue,
-    Text,
-    VStack,
-  } from '@chakra-ui/react';
-  import { HamburgerIcon, CloseIcon } from '@chakra-ui/icons';
-  
-  const navItems = [
-    { label: 'Build Campaign', page: '/ads', isExternal: false},
-    { label: 'Documents', page: 'https://docs.seshatlabs.xyz', isExternal: true },
-    { label: 'Profile', page: '/profile', isExternal: false },
-  ];
-  
-  const Navbar = () => {
-    const { isOpen, onOpen, onClose } = useDisclosure();
-    const linkColor = useColorModeValue('gray.600', 'gray.200');
-    const linkHoverColor = useColorModeValue('gray.800', 'white');
-    const menuItems = (
-      <>
-        {navItems.map((navItem) => (
-          <Box key={navItem.label}>
-            <Link
-              href={navItem.page ?? '#'}
-              fontSize={'sm'}
-              fontWeight={500}
-              color={linkColor}
-              _hover={{
-                textDecoration: 'none',
-                color: linkHoverColor,
-              }}
-              onClick={() => {
-                if (navItem.isExternal) {
-                  window.location.href = navItem.page;
-                }
-              }}
-            >
-              {navItem.label}
-            </Link>
-          </Box>
-        ))}
-      </>
-    );
-    return (
-      <Box>
-        <Flex
-          bg={useColorModeValue('white', 'gray.800')}
-          color={useColorModeValue('gray.600', 'white')}
-          minH={'60px'}
-          py={{ base: 2 }}
-          px={{ base: 4 }}
-          borderBottom={1}
-          borderStyle={'solid'}
-          borderColor={useColorModeValue('gray.200', 'gray.900')}
-          align={'center'}
-          justify={'space-between'}
-        >
-          <Box>
-          <Link href="/">
-            <Text fontSize="lg" fontWeight="bold" paddingLeft={{base: '0', md: '100px'}}> 
-              Seshat Labs
-            </Text>
-            </Link>
-          </Box>
-          <Flex display={{ base: 'none', md: 'flex' }} ml={10}>
-            <HStack spacing={4} paddingRight={'100px'}>{menuItems}</HStack>
-          </Flex>
-          <Box display={{ base: 'block', md: 'none' }}>
-            <IconButton
-              aria-label="Open menu"
-              size="lg"
-              icon={<HamburgerIcon />}
-              onClick={onOpen}
-              variant="ghost"
-            />
-          </Box>
-        </Flex>
-        <Box
-          bg={useColorModeValue('white', 'gray.800')}
-          color={useColorModeValue('gray.600', 'white')}
-          display={{ base: isOpen ? 'block' : 'none', md: 'none' }}
-          position={{ base: 'absolute', md: 'static' }}
-          top={{ base: '60px', md: '0' }}
-          left={{ base: 0, md: 'auto' }}
-          right={{ base: 0, md: 0 }}
-          width={{ base: 'full', md: 'auto' }}
-          mt={{ base: 4, md: 0 }}
-          py={{ base: 4 }}
-          px={{ base: 4, md: 0 }}
-          zIndex={9999}
-        >
-          <Box display={{ base: 'flex', md: 'none' }} justifyContent="flex-end">
-            <IconButton
-              size="md"
-              aria-label="Close menu"
-              icon={<CloseIcon />}
-              onClick={onClose}
-              variant="ghost"
-            />
-          </Box>
-          <VStack spacing={4}>{menuItems}</VStack>
+  Box,
+  Flex,
+  HStack,
+  IconButton,
+  Link,
+  useDisclosure,
+  useColorModeValue,
+  Text,
+  VStack,
+  Button,
+  Spacer,
+} from "@chakra-ui/react";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import { HamburgerIcon, CloseIcon } from "@chakra-ui/icons";
+import NextLink from "next/link";
+
+const navItems = [
+  { label: "Products", page: "/ads", isExternal: false },
+  { label: "Docs", page: "https://docs.seshatlabs.xyz", isExternal: true },
+];
+
+const Navbar = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const linkColor = useColorModeValue("gray.600", "gray.200");
+  const linkHoverColor = useColorModeValue("gray.800", "white");
+  const { user } = useUser();
+
+  const menuItems = (
+    <>
+      {navItems.map((navItem) => (
+        <Box key={navItem.label}>
+          <Link
+            as={NextLink}
+            href={navItem.page ?? "#"}
+            fontSize={"sm"}
+            fontWeight={500}
+            color={linkColor}
+            _hover={{
+              textDecoration: "none",
+              color: linkHoverColor,
+            }}
+            onClick={() => {
+              if (navItem.isExternal) {
+                window.location.href = navItem.page;
+              }
+            }}
+          >
+            {navItem.label}
+          </Link>
         </Box>
+      ))}
+    </>
+  );
+
+  return (
+    <Box>
+      <Flex
+        bg={useColorModeValue("white", "gray.800")}
+        color={useColorModeValue("gray.600", "white")}
+        minH={"60px"}
+        py={{ base: 2 }}
+        px={{ base: 4 }}
+        borderBottom={1}
+        borderStyle={"solid"}
+        borderColor={useColorModeValue("gray.200", "gray.900")}
+        align={"center"}
+        justify={"flex-start"}
+      >
+        <Box>
+          <Link as={NextLink} href="/">
+            <Text
+              fontSize="lg"
+              fontWeight="bold"
+              paddingLeft={{ base: "0", md: "100px" }}
+            >
+              Seshat
+            </Text>
+          </Link>
+        </Box>
+        <Flex display={{ base: "none", md: "flex" }} ml={10}>
+          <HStack spacing={4} paddingRight={"100px"}>
+            {menuItems}
+          </HStack>
+        </Flex>
+        <Spacer />
+        <Link as={NextLink} href="/profile">
+          <Button variant="outline" colorScheme="blue">
+            {user ? "Profile" : "Let's start"}
+          </Button>
+        </Link>
+        <Box display={{ base: "block", md: "none" }}>
+          <IconButton
+            aria-label="Open menu"
+            size="lg"
+            icon={<HamburgerIcon />}
+            onClick={onOpen}
+            variant="ghost"
+          />
+        </Box>
+      </Flex>
+      <Box
+        bg={useColorModeValue("white", "gray.800")}
+        color={useColorModeValue("gray.600", "white")}
+        display={{ base: isOpen ? "block" : "none", md: "none" }}
+        position={{ base: "absolute", md: "static" }}
+        top={{ base: "60px", md: "0" }}
+        left={{ base: 0, md: "auto" }}
+        right={{ base: 0, md: 0 }}
+        width={{ base: "full", md: "auto" }}
+        mt={{ base: 4, md: 0 }}
+        py={{ base: 4 }}
+        px={{ base: 4, md: 0 }}
+        zIndex={9999}
+      >
+        <Box display={{ base: "flex", md: "none" }} justifyContent="flex-end">
+          <IconButton
+            size="md"
+            aria-label="Close menu"
+            icon={<CloseIcon />}
+            onClick={onClose}
+            variant="ghost"
+          />
+        </Box>
+        <VStack spacing={4}>{menuItems}</VStack>
       </Box>
-    );
-  };
-  
+    </Box>
+  );
+};
 
 export default Navbar;

--- a/components/Profile/MetaMaskConnector.js
+++ b/components/Profile/MetaMaskConnector.js
@@ -1,0 +1,38 @@
+import { Box, Button, Container, Link } from "@chakra-ui/react";
+import NextLink from "next/link";
+import { useMetaMask } from "../../hooks/useMetaMask";
+import { MetaMaskError } from "./MetaMaskError";
+export const MetaMaskConnector = () => {
+  const {
+    wallet,
+    hasProvider,
+    isConnecting,
+    connectMetaMask,
+    isMetaMaskInstalled,
+  } = useMetaMask();
+
+  return (
+    <>
+      <Box>
+        {!hasProvider && (
+          <Link as={NextLink} href="https://metamask.io" target="_blank">
+            Install MetaMask
+          </Link>
+        )}
+        {isMetaMaskInstalled && wallet.accounts.length < 1 && (
+          <Button
+            variant="outline"
+            colorScheme="blue"
+            disabled={isConnecting}
+            onClick={connectMetaMask}
+          >
+            Connect MetaMask Wallet
+          </Button>
+        )}
+      </Box>
+      <Container>
+        <MetaMaskError />
+      </Container>
+    </>
+  );
+};

--- a/components/Profile/MetaMaskError.js
+++ b/components/Profile/MetaMaskError.js
@@ -1,0 +1,29 @@
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Box,
+  Container,
+} from "@chakra-ui/react";
+import { useMetaMask } from "../../hooks/useMetaMask";
+
+export const MetaMaskError = () => {
+  const { error, errorMessage, clearError } = useMetaMask();
+  return (
+    <Container
+      maxW="xl"
+      mt={10}
+      textAlign="center"
+      style={error ? { backgroundColor: "red" } : { display: "none" }}
+    >
+      <Alert status="error">
+        <AlertIcon />
+        <AlertTitle>Metamask Error</AlertTitle>
+        <AlertDescription>
+          {error && <Box onClick={clearError}>{errorMessage}</Box>}
+        </AlertDescription>
+      </Alert>
+    </Container>
+  );
+};

--- a/components/Profile/MetaMaskWalletInfo.js
+++ b/components/Profile/MetaMaskWalletInfo.js
@@ -1,0 +1,38 @@
+import { Box, Link, Text } from "@chakra-ui/react";
+import NextLink from "next/link";
+import { useMetaMask } from "../../hooks/useMetaMask";
+
+export const MetaMaskWalletInfo = () => {
+  const { wallet } = useMetaMask();
+
+  const formatChainAsNum = (chainIdHex) => {
+    const chainIdNum = parseInt(chainIdHex);
+    return chainIdNum;
+  };
+
+  const formatAddress = (addr) => {
+    return `${addr.substring(0, 8)}...`;
+  };
+
+  return (
+    <Box>
+      {wallet.accounts.length > 0 && (
+        <>
+          <Text>
+            Etherscan Wallet Account:{" "}
+            <Link
+              as={NextLink}
+              href={`https://etherscan.io/address/${wallet.accounts[0]}`}
+              target="_blank"
+            >
+              {formatAddress(wallet.accounts[0])}
+            </Link>
+          </Text>
+          <Text>Wallet Balance: {wallet.balance}</Text>
+          <Text>Hex ChainId: {wallet.chainId}</Text>
+          <Text>Numeric ChainId: {formatChainAsNum(wallet.chainId)}</Text>
+        </>
+      )}
+    </Box>
+  );
+};

--- a/hooks/useMetaMask.js
+++ b/hooks/useMetaMask.js
@@ -1,0 +1,150 @@
+import {
+  useState,
+  useEffect,
+  createContext,
+  useContext,
+  useCallback,
+} from "react";
+
+import detectEthereumProvider from "@metamask/detect-provider";
+
+// interface WalletState {
+//   accounts: any[]
+//   balance: string
+//   chainId: string
+// }
+
+// interface MetaMaskContextData {
+//   wallet: WalletState
+//   hasProvider: boolean | null
+//   error: boolean
+//   errorMessage: string
+//   isConnecting: boolean
+//   connectMetaMask: () => void
+//   clearError: () => void
+// }
+
+const formatBalance = (rawBalance) => {
+  const balance = (parseInt(rawBalance) / 1000000000000000000).toFixed(2);
+  return balance;
+};
+
+const disconnectedState = { accounts: [], balance: "", chainId: "" };
+
+const MetaMaskContext = createContext({});
+
+export const MetaMaskContextProvider = ({ children }) => {
+  const [hasProvider, setHasProvider] = useState(null);
+
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  const [errorMessage, setErrorMessage] = useState("");
+  const clearError = () => setErrorMessage("");
+
+  const [isMetaMaskInstalled, setIsMetaMaskInstalled] = useState(false);
+
+  const [wallet, setWallet] = useState(disconnectedState);
+
+  // useCallback ensures that you don't uselessly recreate the _updateWallet function on every render
+  const _updateWallet = useCallback(async (providedAccounts) => {
+    const accounts =
+      providedAccounts ||
+      (await window.ethereum.request({ method: "eth_accounts" }));
+
+    if (accounts.length === 0) {
+      // If there are no accounts, then the user is disconnected
+      setWallet(disconnectedState);
+      return;
+    }
+
+    const balance = formatBalance(
+      await window.ethereum.request({
+        method: "eth_getBalance",
+        params: [accounts[0], "latest"],
+      })
+    );
+    const chainId = await window.ethereum.request({
+      method: "eth_chainId",
+    });
+
+    setWallet({ accounts, balance, chainId });
+  }, []);
+
+  const updateWalletAndAccounts = useCallback(
+    () => _updateWallet(),
+    [_updateWallet]
+  );
+  const updateWallet = useCallback(
+    (accounts) => _updateWallet(accounts),
+    [_updateWallet]
+  );
+
+  /**
+   * This logic checks if MetaMask is installed. If it is, some event handlers are set up
+   * to update the wallet state when MetaMask changes. The function returned by useEffect
+   * is used as a "cleanup": it removes the event handlers whenever the MetaMaskProvider
+   * is unmounted.
+   */
+  useEffect(() => {
+    const getProvider = async () => {
+      const provider = await detectEthereumProvider({ silent: true });
+      setHasProvider(Boolean(provider));
+
+      if (provider) {
+        updateWalletAndAccounts();
+        setIsMetaMaskInstalled(window.ethereum?.isMetaMask);
+        window.ethereum.on("accountsChanged", updateWallet);
+        window.ethereum.on("chainChanged", updateWalletAndAccounts);
+      }
+    };
+
+    getProvider();
+
+    return () => {
+      window.ethereum?.removeListener("accountsChanged", updateWallet);
+      window.ethereum?.removeListener("chainChanged", updateWalletAndAccounts);
+    };
+  }, [updateWallet, updateWalletAndAccounts]);
+
+  const connectMetaMask = async () => {
+    setIsConnecting(true);
+
+    try {
+      const accounts = await window.ethereum.request({
+        method: "eth_requestAccounts",
+      });
+      clearError();
+      updateWallet(accounts);
+    } catch (err) {
+      setErrorMessage(err.message);
+    }
+    setIsConnecting(false);
+  };
+
+  return (
+    <MetaMaskContext.Provider
+      value={{
+        wallet,
+        hasProvider,
+        error: !!errorMessage,
+        errorMessage,
+        isConnecting,
+        isMetaMaskInstalled,
+        connectMetaMask,
+        clearError,
+      }}
+    >
+      {children}
+    </MetaMaskContext.Provider>
+  );
+};
+
+export const useMetaMask = () => {
+  const context = useContext(MetaMaskContext);
+  if (context === undefined) {
+    throw new Error(
+      'useMetaMask must be used within a "MetaMaskContextProvider"'
+    );
+  }
+  return context;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@chakra-ui/react": "^2.4.9",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
+        "@metamask/detect-provider": "^2.0.0",
         "@next-auth/mongodb-adapter": "^1.1.1",
         "auth0-lock": "^12.0.2",
         "axios": "^1.2.1",
@@ -3836,6 +3837,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@metamask/detect-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-2.0.0.tgz",
+      "integrity": "sha512-sFpN+TX13E9fdBDh9lvQeZdJn4qYoRb/6QF2oZZK/Pn559IhCFacPMU1rMuqyXoFQF3JSJfii2l98B87QDPeCQ==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@motionone/animation": {
@@ -15048,6 +15057,11 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "@metamask/detect-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-2.0.0.tgz",
+      "integrity": "sha512-sFpN+TX13E9fdBDh9lvQeZdJn4qYoRb/6QF2oZZK/Pn559IhCFacPMU1rMuqyXoFQF3JSJfii2l98B87QDPeCQ=="
     },
     "@motionone/animation": {
       "version": "10.15.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@chakra-ui/react": "^2.4.9",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@metamask/detect-provider": "^2.0.0",
     "@next-auth/mongodb-adapter": "^1.1.1",
     "auth0-lock": "^12.0.2",
     "axios": "^1.2.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,15 @@
 import { ChakraProvider } from "@chakra-ui/react";
 import "../styles/globals.css";
 import { UserProvider } from "@auth0/nextjs-auth0/client";
+import { MetaMaskContextProvider } from "../hooks/useMetaMask";
 
 function MyApp({ Component, pageProps: { session, ...pageProps } }) {
   return (
     <UserProvider>
       <ChakraProvider>
-        <Component {...pageProps} />
+        <MetaMaskContextProvider>
+          <Component {...pageProps} />
+        </MetaMaskContextProvider>
       </ChakraProvider>
     </UserProvider>
   );

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,22 +1,27 @@
 import { useUser } from "@auth0/nextjs-auth0/client";
-import NextLink from "next/link";
 import {
-  Button,
   Box,
-  Text,
-  Heading,
+  Button,
   Container,
-  Spacer,
+  Heading,
   Menu,
   MenuButton,
-  MenuList,
   MenuItem,
+  MenuList,
+  Spacer,
+  Text,
+  Flex,
 } from "@chakra-ui/react";
+import NextLink from "next/link";
+import { useMetaMask } from "../hooks/useMetaMask";
 import Header from "../components/Header";
+import { MetaMaskConnector } from "../components/Profile/MetaMaskConnector";
+import { MetaMaskWalletInfo } from "../components/Profile/MetaMaskWalletInfo";
 import Login from "../components/Utilities/Login";
 
 function UserProfile() {
   const { user, error, isLoading } = useUser();
+  const { wallet, hasProvider } = useMetaMask();
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -37,7 +42,7 @@ function UserProfile() {
     return (
       <>
         <Header />
-        <Container maxW="xl" mt={20}>
+        <Container maxW="3xl" mt={20}>
           <Box p={5} borderWidth="1px" borderRadius="lg">
             <Heading size="xl">Welcome, {user.name}!</Heading>
             <Text mt={4} fontSize="lg">
@@ -47,6 +52,22 @@ function UserProfile() {
               Your Publisher/DApp Developer API Key:{" "}
               {user.seshat_API_keys.publisherAPIKey}
             </Text>
+
+            <Spacer mt={4} />
+
+            {hasProvider && wallet.accounts.length > 0 ? (
+              <MetaMaskWalletInfo />
+            ) : (
+              <>
+                <Text fontSize="lg">
+                  Add Wallet: To create an actual campaign you need to deposit
+                  fund, or to withdraw your revenue as a publisher
+                </Text>
+                <Spacer mt={4} />
+                <MetaMaskConnector />
+              </>
+            )}
+
             <Spacer mt={6} />
             <Menu>
               <MenuButton as={Button} colorScheme="blue">


### PR DESCRIPTION
## SOC 129 
Adds a useMetaMask() hook to allow to do the following:
- Allow authenticated users to connect their MetaMask wallet to the site
- Display MetaMask wallet info in /profile
- Display MetaMask errors to the user

Conditionally renders the text of the "profile" button 

Currently, only Ethereum is supported

[Short video displaying the behavior of the change](https://github.com/seankhatiri/seshat/assets/41768142/95e1a2ea-1d5f-445e-b08f-99f22d7b2a38)
